### PR TITLE
Rendering jobs via Searchkit.co

### DIFF
--- a/jobs.html
+++ b/jobs.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- searchkit.co CDN includes. See http://docs.searchkit.co/stable/docs/setup/project-setup.html -->
+    <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/searchkit/0.9.2/theme.css">
+
+    <!-- Custom JS/CSS -->
+    <link rel="stylesheet" type="text/css" href="css/styles.css">
+
+    <meta charset="UTF-8">
+    <title>PacBio LIMS</title>
+</head>
+<body>
+
+<div id="jobs"></div>
+
+<!-- searchkit.co CDN includes but with latest react/babel. See http://docs.searchkit.co/stable/docs/setup/project-setup.html -->
+<script src="https://fb.me/react-15.0.2.js"></script>
+<script src="https://fb.me/react-dom-15.0.2.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-core/5.8.23/browser.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/searchkit/0.9.2/bundle.js"></script>
+
+<!-- Custom JS -->
+<script type="text/babel" src="js/app.js"></script>
+<script type="text/babel" src="js/jobs.js"></script>
+
+</body>
+</html>

--- a/js/jobs.js
+++ b/js/jobs.js
@@ -5,9 +5,11 @@ const Hits = Searchkit.Hits
 const NoHits = Searchkit.NoHits
 const Pagination = Searchkit.Pagination
 
+// utility code for pretty-printing
+const formatDate = Window.App.formatDate
+
 
 class JobTable extends React.Component {
-
 
     render(){
         const { hits } = this.props
@@ -17,7 +19,10 @@ class JobTable extends React.Component {
             <table className="sk-table sk-table-striped" style={{width: '100%', boxSizing: 'border-box'}}>
             <thead>
                 <tr>
-                <th>UUID</th>
+                    <th>UUID</th>
+                    <th>Name</th>
+                    <th>Created</th>
+                    <th>Updated</th>
                 </tr>
             </thead>
             <tbody>
@@ -25,6 +30,9 @@ class JobTable extends React.Component {
                 return (
                 <tr key={hit._id}>
                     <td>{hit._source.job_uuid}</td>
+                    <td>{hit._source.name}</td>
+                    <td>{formatDate(hit._source.created_at)}</td>
+                    <td>{formatDate(hit._source.updated_at)}</td>
                 </tr>
             )})}
             </tbody>
@@ -46,7 +54,7 @@ class JobSearch extends React.Component {
             <Searchbox searchOnChange={true} prefixQueryFields={["job_uuid^1"]} />
             </div>
             <div className="search__results">
-            <Hits hitsPerPage={10} sourceFilter={["job_uuid"]} listComponent={JobTable}/>
+            <Hits hitsPerPage={10} sourceFilter={["job_uuid", "name", "created_at", "updated_at"]} listComponent={JobTable}/>
             <NoHits translations={{
             "NoHits.NoResultsFound":"No matches found for {query}",
                 "NoHits.DidYouMean":"Search for {suggestion}",

--- a/js/jobs.js
+++ b/js/jobs.js
@@ -1,0 +1,64 @@
+// search using the index
+const sk = new Searchkit.SearchkitManager(Window.App.host + "smrtlink_analysis_jobs_v1/smrtlink_analysis_job/")
+
+const Hits = Searchkit.Hits
+const NoHits = Searchkit.NoHits
+const Pagination = Searchkit.Pagination
+
+
+class JobTable extends React.Component {
+
+
+    render(){
+        const { hits } = this.props
+        const hit = hits[0]
+        return (
+            <div style={{width: '100%', boxSizing: 'border-box', padding: 8}}>
+            <table className="sk-table sk-table-striped" style={{width: '100%', boxSizing: 'border-box'}}>
+            <thead>
+                <tr>
+                <th>UUID</th>
+                </tr>
+            </thead>
+            <tbody>
+            { hits.map(hit => {
+                return (
+                <tr key={hit._id}>
+                    <td>{hit._source.job_uuid}</td>
+                </tr>
+            )})}
+            </tbody>
+            </table>
+            </div>
+    )
+    }
+}
+
+class JobSearch extends React.Component {
+    render() {
+        const SearchkitProvider = Searchkit.SearchkitProvider;
+        const Searchbox = Searchkit.SearchBox;
+        return (<div>
+
+            <SearchkitProvider searchkit={sk}>
+            <div className="search">
+            <div className="search__query">
+            <Searchbox searchOnChange={true} prefixQueryFields={["job_uuid^1"]} />
+            </div>
+            <div className="search__results">
+            <Hits hitsPerPage={10} sourceFilter={["job_uuid"]} listComponent={JobTable}/>
+            <NoHits translations={{
+            "NoHits.NoResultsFound":"No matches found for {query}",
+                "NoHits.DidYouMean":"Search for {suggestion}",
+                "NoHits.SearchWithoutFilters":"Search for {query} without filters"
+        }} suggestionsField="job_uuid"/>
+            <Pagination showNumbers={true}/>
+            </div>
+            </div>
+            </SearchkitProvider>
+
+            </div>);
+    }
+}
+
+ReactDOM.render(<JobSearch />, document.getElementById('jobs'));

--- a/js/subreadset.js
+++ b/js/subreadset.js
@@ -20,19 +20,19 @@ class SubreadsetTable extends React.Component {
             <table className="sk-table sk-table-striped" style={{width: '100%', boxSizing: 'border-box'}}>
             <thead>
                 <tr>
-                <th></th>
-                <th>UUID</th>
-                <th>Runcode</th>
-                <th>Created At</th>
-                <th>Path</th>
+                    <th>UUID</th>
+                    <th>Jobs</th>
+                    <th>Runcode</th>
+                    <th>Created At</th>
+                    <th>Path</th>
                 </tr>
             </thead>
             <tbody>
             { hits.map(hit => {
                 return (
                 <tr key={hit._id}>
-                    <td style={{margin: 0, padding: 0, width: 40}}></td>
                     <td>{hit._source.uuid}</td>
+                    <td><a href={"jobs.html?q=" + hit._source.uuid} title="Click to see jobs">?</a></td>
                     <td>{hit._source.runcode}</td>
                     <td>{formatDate(hit._source.created_at)}</td>
                     <td><a href="{hit._source.path}" title={hit._source.path}>...</a></td>


### PR DESCRIPTION
> WIP: example of layering in jobs to match LIMS records

CC @mpkocher

Not ready to merge. Just mocking up the code and showing adding other ReactJS components. See [README.md](https://github.com/jfalkner/SearchkitExample/blob/master/README.md) for the main, initial example.

This adds a "Jobs" link to the results in the main page (subreadset) table.

<img height="300" alt="Jobs links" src="https://cloud.githubusercontent.com/assets/855834/15434316/3e3a29d8-1e84-11e6-9151-857aa60ee653.png">

And clicking shows the jobs details page. For now, I have it as a separate page, meaning needs a round-trip to the server to render. We can move this to a toggled div and single-page model as desired.

<img width="1173" alt="screen shot 2016-05-20 at 12 12 17 pm" src="https://cloud.githubusercontent.com/assets/855834/15434331/503edf20-1e84-11e6-9b1b-5c697de0d44e.png">
