### PR TITLE
5 char UUID + link to full

### DIFF
--- a/js/subreadset.js
+++ b/js/subreadset.js
@@ -34,7 +34,7 @@ class SubreadsetTable extends React.Component {
                 return (
                 <tr key={hit._id}>
                     <td style={{margin: 0, padding: 0, width: 40}}></td>
-                    <td>{hit._source.uuid}</td>
+                    <td>{hit._source.uuid.substring(0, 5)}<super><a href={hit._source.uuid} title={hit._source.uuid}>*</a></super></td>
                     <td>{hit._source.runcode}</td>
                     <td>{formatDate(hit._source.created_at)}</td>
                     <td>{hit._source.inst_name} ({hit._source.inst_id})</td>


### PR DESCRIPTION
CC @mpkocher

Fixes #4 

Now the display shows a succinct UUID with a copy-link for the full. Will refactor to a JS helper function when we need to reused this trimming logic later.

<img width="970" alt="screen shot 2016-05-20 at 12 45 20 pm" src="https://cloud.githubusercontent.com/assets/855834/15435175/bf03a6d0-1e88-11e6-93a3-f3341d8236c8.png">
