### PR TITLE
UUID link shows itself

### DIFF
--- a/js/subreadset.js
+++ b/js/subreadset.js
@@ -36,7 +36,7 @@ class SubreadsetTable extends React.Component {
             { hits.map(hit => {
                 return (
                 <tr key={hit._id}>
-                    <td>{hit._source.uuid.substring(0, 5)}<super><a href={hit._source.uuid} title={hit._source.uuid}>*</a></super></td>
+                    <td>{hit._source.uuid.substring(0, 5)}<super><a href={"?q=\"" + hit._source.uuid + "\""} title={hit._source.uuid}>*</a></super></td>
                     <td>{hit._source.runcode}</td>
                     <td>{formatDate(hit._source.created_at)}</td>
                     <td><a title={hit._source.inst_id}>{hit._source.inst_name}</a></td>


### PR DESCRIPTION
Fixes #15 

Example of the result after clicking a UUID link. Previously, this would 404.

<img width="1070" alt="screen shot 2016-07-08 at 10 40 26 am" src="https://cloud.githubusercontent.com/assets/855834/16691007/afb56592-44f8-11e6-8a01-2ecbe613372f.png">
