### PR TITLE
Sort by created_at by default or relevance

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -45,3 +45,8 @@
   height: 36px;
   padding: 2px;
 }
+
+.sk-select {
+  top: 5px;
+  right: 17px;
+}

--- a/js/subreadset.js
+++ b/js/subreadset.js
@@ -58,6 +58,7 @@ class SubreadsetSearch extends React.Component {
     render() {
         const SearchkitProvider = Searchkit.SearchkitProvider;
         const Searchbox = Searchkit.SearchBox;
+        const SortingSelector = Searchkit.SortingSelector;
         return (
             <div>
                 <SearchkitProvider searchkit={sk}>
@@ -65,6 +66,10 @@ class SubreadsetSearch extends React.Component {
                         <div className="search__query">
                             <div><img id="logo" src="images/lims_logo.svg"/></div>
                             <Searchbox searchOnChange={true} prefixQueryFields={["runcode^3", "uuid^1"]} />
+                            <SortingSelector options={[
+                              {label:"Recent", field:"created_at", order:"desc", defaultOption:true},
+                              {label:"Relevance", field:"_score", order:"desc"}
+                            ]} />
                             <div id="examples"><a href="https://github.com/jfalkner/SearchkitExample/blob/master/README.md">?</a></div>
                         </div>
                         <div className="search__results">


### PR DESCRIPTION
CC @mpkocher

Fixes #14. Now results will show the latest first, based on `created_at`.

Example of a query showing the latest first. See the select box in the top right for toggling `Recent` or `Relevance`.

<img width="1185" alt="screen shot 2016-07-08 at 11 22 32 am" src="https://cloud.githubusercontent.com/assets/855834/16692487/03b4a4d6-44ff-11e6-82e2-3c3b6fb47479.png">
